### PR TITLE
Fix TypeError when handling messages

### DIFF
--- a/src/lib/EthService.js
+++ b/src/lib/EthService.js
@@ -143,6 +143,8 @@ class WebsocketClient {
           }
         }
       }
+    } else if ('error' in message) {
+      console.log(`Message Error (${message['error']['code']}): ${message['error']['message']}`);
     } else if ('id' in message) {
       let caller = this._wscalls[message['id']];
       if (caller) {


### PR DESCRIPTION
Saw this error when testing my bot:
```
bot_1              | TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined
bot_1              |     at WebsocketClient.handle_message (/usr/src/bot/src/lib/EthService.js:152:30)
bot_1              |     at emitOne (events.js:115:13)
bot_1              |     at WebSocket.emit (events.js:210:7)
bot_1              |     at Receiver._receiver.onmessage (/usr/src/bot/node_modules/ws/lib/WebSocket.js:146:47)
bot_1              |     at Receiver.dataMessage (/usr/src/bot/node_modules/ws/lib/Receiver.js:389:14)
bot_1              |     at Receiver.getData (/usr/src/bot/node_modules/ws/lib/Receiver.js:330:12)
bot_1              |     at Receiver.startLoop (/usr/src/bot/node_modules/ws/lib/Receiver.js:165:16)
bot_1              |     at Receiver.add (/usr/src/bot/node_modules/ws/lib/Receiver.js:139:10)
bot_1              |     at TLSSocket._ultron.on (/usr/src/bot/node_modules/ws/lib/WebSocket.js:142:22)
bot_1              |     at emitOne (events.js:115:13)
```

Not sure exactly what the root cause is but handling the error stops the bot from crashing.