### PR TITLE
Modified template with base64 image attachment and server-side image rendering support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM node:latest
 RUN git config --global user.email 'docker-dummy@example.com'
 RUN npm install -g nodemon
 
+# install node-canvas for server-side image manipulation
+RUN apt-get update \
+    && apt-get install -qq libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential g++
+    
 # use cached layer for node modules
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install --unsafe-perm

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The bot built on this template will be able to:
 * send messages as text or image (either by local file url inside the "attachments" folder or a base64 data uri)
 * send and request money
 * create simple UI for buttons and menus
+* create server-side images and get a base64 data uri for them
 * store sessions and state for each user
 
 ## Launch a Heroku app using this template
@@ -31,6 +32,29 @@ To reset the postgres database in your dev environment you can use
 
 ```
 docker-compose down -v
+```
+
+## Example: create server-side image and send to Token Bot
+
+```
+var Canvas = require('canvas')
+  , Image = Canvas.Image
+  , canvas = new Canvas(200, 200)
+  , ctx = canvas.getContext('2d');
+
+ctx.font = '30px Impact';
+ctx.fillText("Hi Proffer, Hi Token!", 50, 100);
+
+var te = ctx.measureText('Awesome!');
+ctx.strokeStyle = 'rgba(0,0,0,0.5)';
+ctx.beginPath();
+ctx.lineTo(50, 102);
+ctx.lineTo(50 + te.width, 102);
+ctx.stroke();
+
+// and then in bot.js, use the built-in sendImageMessage function
+// except no need to pass in the url of a file in the 'attachments' folder
+sendImageMessage(session, canvas.toDataURL(), controls)
 ```
 
 ## See also

--- a/README.md
+++ b/README.md
@@ -1,30 +1,19 @@
-# Token SOFA App
+# Modified Token App Template
 
-This repo helps you build a [Token app](https://www.tokenbrowser.com) in Javascript.
+This repo helps you build a [Token app](https://www.tokenbrowser.com) in Javascript. It modifies the app template provided by the tokenbrowser team by adding support for sending base64 image data as an attachment.
 
-The sample bot can:
+The bot built on this template will be able to:
 
-* send messages
+* send messages as text or image (either by local file url inside the "attachments" folder or a base64 data uri)
 * send and request money
 * create simple UI for buttons and menus
 * store sessions and state for each user
 
-TODO
+## Launch a Heroku app using this template
 
-* sending image messages
-* creating web view UIs
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/proffernetwork/token-app-template)
 
-## Launch your own Token app in 5 minutes
-
-Read our [guide to creating a Token app](http://developers.tokenbrowser.com/docs/creating-a-token-app).
-
-When ready, fork this repo and deploy it to Heroku.
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
-Then check out [`src/bot.js`](src/bot.js) to start changing the bot logic.
-
-## Running locally with Docker
+## Run app locally with Docker
 
 You can run the project locally with
 
@@ -43,21 +32,6 @@ To reset the postgres database in your dev environment you can use
 ```
 docker-compose down -v
 ```
-
-## Architecture
-
-Deploying a Token app requires a few processes to run:
-
-* **token-headless-client**<br>
-  This is a client we provide (similar to the iOS or Android client) that provides a wrapper around the Token backend services. It also handles end-to-end encrypting all messages using the Signal protocol. It is written in Java and runs in the background, proxying all the requests to amd from your bot.
-* **redis**<br>
-  We use redis pub/sub to provide a connection between the token-headless-client and your bot.
-* **bot.js**<br>
-  This is where all your app logic lives.
-* **postgres**<br>
-  Postgres is used to store session data so you can persist state for each user who talks to your bot (similar to cookies in a web browser).
-
-![diagram](docs/images/app-architecture.png)
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The bot built on this template will be able to:
 
 ## Example: create server-side image and send to Token Bot
 
+Add node-canvas npm module to package.json:
+```
+npm install canvas --save
+```
+
+Then you can put your canvas drawing code anywhere in your bot source files:
+
 ```
 var Canvas = require('canvas')
   , Image = Canvas.Image

--- a/README.md
+++ b/README.md
@@ -14,6 +14,36 @@ The bot built on this template will be able to:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/proffernetwork/token-app-template)
 
+## Example: create server-side image and send to Token Bot
+
+```
+var Canvas = require('canvas')
+  , Image = Canvas.Image
+  , canvas = new Canvas(200, 200)
+  , ctx = canvas.getContext('2d');
+
+ctx.font = '30px Impact';
+ctx.fillText("Hi Proffer, Hi Token!", 50, 100);
+
+// and then in bot.js, use the built-in message-sending code
+// except no need to pass in the url of a file in the 'attachments' folder
+sendImageMessage(session, canvas.toDataURL(), controls)
+
+// url can either be path of file within 'attachments' or a base64 data uri
+function sendImageMessage(session, imageURL, controls){
+  session.reply(SOFA.Message({
+    showKeyboard: false,
+    controls,
+    attachments: [
+       {
+         "type": "image/jpeg",
+         "url": imageURL
+       }
+    ]
+  }))
+}
+```
+
 ## Run app locally with Docker
 
 You can run the project locally with
@@ -34,29 +64,6 @@ To reset the postgres database in your dev environment you can use
 docker-compose down -v
 ```
 
-## Example: create server-side image and send to Token Bot
-
-```
-var Canvas = require('canvas')
-  , Image = Canvas.Image
-  , canvas = new Canvas(200, 200)
-  , ctx = canvas.getContext('2d');
-
-ctx.font = '30px Impact';
-ctx.fillText("Hi Proffer, Hi Token!", 50, 100);
-
-var te = ctx.measureText('Awesome!');
-ctx.strokeStyle = 'rgba(0,0,0,0.5)';
-ctx.beginPath();
-ctx.lineTo(50, 102);
-ctx.lineTo(50 + te.width, 102);
-ctx.stroke();
-
-// and then in bot.js, use the built-in sendImageMessage function
-// except no need to pass in the url of a file in the 'attachments' folder
-sendImageMessage(session, canvas.toDataURL(), controls)
-```
-
 ## See also
-
+* [https://github.com/Automattic/node-canvas]
 * [https://www.tokenbrowser.com]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Modified Token App Template
 
-This repo helps you build a [Token app](https://www.tokenbrowser.com) in Javascript. It modifies the app template provided by the tokenbrowser team by adding support for sending base64 image data as an attachment.
+This repo helps you build a [Token app](https://www.tokenbrowser.com) in Javascript. It modifies the app template provided by the tokenbrowser team by adding support for sending base64 image data as an attachment, and for doing server-side image rendering in the bot application code using node-canvas.
 
 The bot built on this template will be able to:
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
-  "name": "Token Sofa App",
-  "description": "Foundation for building a SOFA app for Token (Chat Bot / Web View)",
-  "repository": "https://github.com/tokenbrowser/token-sofa-app",
+  "name": "Sample Token App with Base64 Image Support",
+  "description": "Foundation for building a SOFA app for Token (Chat Bot / Web View). Modified by Proffer Network to include base64 image sending and server-side node-canvas image rendering support.",
+  "repository": "https://github.com/proffernetwork/token-app-template",
   "env": {
     "TOKEN_APP_SEED": {
       "description": "12 word secret backup phrase"
@@ -29,6 +29,9 @@
     }
   },
   "addons": [
+      {
+        "plan": "mongolab"
+      },
       {
         "plan": "heroku-redis:hobby-dev"
       },{

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sample Token App with Proffer modifications",
+  "name": "Sample Token App",
   "description": "Modified to include base64 image sending and server-side image rendering using node-canvas.",
   "repository": "https://github.com/proffernetwork/token-app-template",
   "env": {

--- a/app.json
+++ b/app.json
@@ -30,9 +30,6 @@
   },
   "addons": [
       {
-        "plan": "mongolab"
-      },
-      {
         "plan": "heroku-redis:hobby-dev"
       },{
         "plan": "heroku-postgresql:hobby-dev"

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "Sample Token App with Base64 Image Support",
-  "description": "Foundation for building a SOFA app for Token (Chat Bot / Web View). Modified by Proffer Network to include base64 image sending and server-side node-canvas image rendering support.",
+  "name": "Sample Token App with Proffer modifications",
+  "description": "Modified to include base64 image sending and server-side image rendering using node-canvas.",
   "repository": "https://github.com/proffernetwork/token-app-template",
   "env": {
     "TOKEN_APP_SEED": {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 task stage(type: FatCapsule) {
   applicationClass 'com.bakkenbaeck.token.headless.TokenHeadlessClient'
   baseName 'token-headless-client'
+  version = '0.1.2'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,8 @@ repositories {
 task stage(type: FatCapsule) {
   applicationClass 'com.bakkenbaeck.token.headless.TokenHeadlessClient'
   baseName 'token-headless-client'
-  version = '0.1.2'
 }
 
 dependencies {
-  compile 'com.github.tokenbrowser:token-headless-client:v0.1.2'
+  compile 'com.github.proffernetwork:token-headless-client:master-SNAPSHOT'
 }

--- a/dependencies/headless-client/Dockerfile
+++ b/dependencies/headless-client/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 WORKDIR /usr/src/headless-client
 
-RUN git clone https://github.com/tokenbrowser/token-headless-client.git . && git fetch --tags && git checkout tags/v0.1.2
+RUN git clone https://github.com/proffernetwork/token-headless-client .
 
 RUN ./gradlew TokenHeadlessClientCapsule
 


### PR DESCRIPTION
Hey Token team, 

This is a one-click deploy template for a modified version of your app with two additions:
1) base64 image attachments (via a modified headless-client)
2) server-side image rendering (via addition of node-canvas on the bot app)

The changes in this repo are minimal. The bulk of the changes are to the headless-client itself, which we have submitted as a separate pull-request. However, we saw your email this morning reminding and recommending that we submit our modifications via pull-requests so submitting this one as well.